### PR TITLE
rg-30: Add Data Wrapper

### DIFF
--- a/frontend/src/bundles/common/components/data-wrapper/data-wrapper.tsx
+++ b/frontend/src/bundles/common/components/data-wrapper/data-wrapper.tsx
@@ -1,0 +1,39 @@
+import { type FC } from 'react';
+
+import { type DataWrapperProperties } from '~/bundles/common/types/data-wrapper/data-wrapper-properties.type';
+
+import styles from './styles.module.scss';
+
+const DataWrapper: FC<DataWrapperProperties> = ({
+    isLoading,
+    hasData,
+    children,
+    customSpinnerElement,
+    customMessageElement
+}) => {
+    const defaultSpinnerElement =
+        <div className={styles.data_wrapper__spinner}></div>;
+
+    const defaultMessageElement =
+        <h2 className={styles.data_wrapper__message}>
+            There is no data available. Please, try again later.
+        </h2>;
+
+    if (isLoading) {
+        return (
+            <div className={styles.data_wrapper__container}>
+            {customSpinnerElement ?? defaultSpinnerElement}
+            </div>
+        );
+    }
+    if (!hasData) {
+        return (
+            <div className={styles.data_wrapper__container}>
+                {customMessageElement ?? defaultMessageElement}
+            </div>
+        );
+    }
+    return <>{children}</>;
+};
+
+export { DataWrapper };

--- a/frontend/src/bundles/common/components/data-wrapper/styles.module.scss
+++ b/frontend/src/bundles/common/components/data-wrapper/styles.module.scss
@@ -1,0 +1,29 @@
+@import url('../../../../assets/css/variables.scss');
+
+@keyframes spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.data_wrapper__container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+}
+
+.data_wrapper__spinner {
+    width: 50px;
+    height: 50px;
+    border: 5px solid #CCD7DC;
+    border-top-color: #DBAE2D;
+    border-radius: 50%;
+    animation: spin 0.5s infinite linear;
+}
+
+.data_wrapper__message {
+    font-size: var(--font-size-title-h2);
+    font-family: var(--font-family-main);
+}

--- a/frontend/src/bundles/common/types/data-wrapper/data-wrapper-properties.type.ts
+++ b/frontend/src/bundles/common/types/data-wrapper/data-wrapper-properties.type.ts
@@ -1,0 +1,11 @@
+import { type ReactElement, type ReactNode } from 'react';
+
+type DataWrapperProperties = {
+    isLoading: boolean,
+    hasData: boolean,
+    children: ReactNode,
+    customSpinnerElement?: ReactElement,
+    customMessageElement?: ReactElement
+};
+
+export { type DataWrapperProperties };


### PR DESCRIPTION
Added a data wrapper component which displays a spinner if data is currently loading. If loading is complete but there is no data available, it shows a message indicating that. If the data is loaded successfully, it renders the children components. Also you can use custom spinner and message elements.

**1. Spinner if loading is active**
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/60217935/183ef453-3942-4d95-97ce-122df3d5d0b1)
**2. Message shown if loading is done but there is no data**
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/60217935/74f12789-ac1b-4f67-a42d-4b02427e4b6a)
**3. Children component rendered if data is loaded successfully**
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/60217935/8026620d-0204-43c6-9947-d6b8a0896163)
