### PR TITLE
rg-96: remove trim in password validation

### DIFF
--- a/frontend/src/bundles/auth/components/sign-up-form/validation/sign-up-validation.ts
+++ b/frontend/src/bundles/auth/components/sign-up-form/validation/sign-up-validation.ts
@@ -32,9 +32,9 @@ const userSignUpValidationFrontend = joi.object<
             'string.email': UserValidationMessage.EMAIL_WRONG,
             'string.empty': UserValidationMessage.EMAIL_REQUIRE,
         }),
-    password: joi.string().trim().regex(/^\S*$/).required().messages({
+    password: joi.string().regex(/^\S*$/).required().messages({
         'string.empty': UserValidationMessage.PASSWORD_REQUIRED,
-        'string.pattern.base': UserValidationMessage.PASSWORD_NO_SPACES,
+        'string.pattern.base': UserValidationMessage.PASSWORD_INVALID,
     }),
     confirm_password: joi
         .string()

--- a/shared/src/bundles/users/enums/user-validation-message.enum.ts
+++ b/shared/src/bundles/users/enums/user-validation-message.enum.ts
@@ -4,7 +4,7 @@ enum UserValidationMessage {
     EMAIL_REQUIRE = 'Email is required',
     EMAIL_WRONG = 'Email is wrong',
     PASSWORD_REQUIRED = 'Password is required',
-    PASSWORD_NO_SPACES = 'No spaces allowed',
+    PASSWORD_INVALID = 'Invalid password. Use 8-64 characters, mix uppercase, lowercase, numbers, and special characters. No spaces allowed',
     CONFIRM_PASSWORD_REQUIRED = 'Confirm password required',
     CONFIRM_PASSWORD_MATCH = 'Confirm password should match the password',
 }


### PR DESCRIPTION
I've removed trim because spaces in the beginning and end aren't allowed