### PR TITLE
rg-133: replace templates with recently viewed templates

### DIFF
--- a/backend/src/bundles/recently-viewed/helpers/get-unique-templates-viewed-by-user.ts
+++ b/backend/src/bundles/recently-viewed/helpers/get-unique-templates-viewed-by-user.ts
@@ -1,0 +1,31 @@
+import {
+    type RecentlyViewedTemplatesQueryResult,
+    type RecentlyViewedTemplatesResponseDto,
+} from '../types/types';
+
+const getUniqueTemplatesViewedByUser = (
+    recentlyViewed: RecentlyViewedTemplatesQueryResult[],
+): RecentlyViewedTemplatesResponseDto[] => {
+    const uniqueTemplateIds = new Set<string>();
+    const recentlyViewedUniqueTemplates: RecentlyViewedTemplatesResponseDto[] =
+        [];
+
+    for (const item of recentlyViewed) {
+        if (!uniqueTemplateIds.has(item.templateId)) {
+            uniqueTemplateIds.add(item.templateId);
+            recentlyViewedUniqueTemplates.push({
+                id: item.id,
+                userId: item.userId,
+                resumeId: item.resumeId,
+                resumeTitle: item.resumes.resumeTitle,
+                templateId: item.templateId,
+                template: item.templates,
+                viewedAt: item.viewedAt,
+            });
+        }
+    }
+
+    return recentlyViewedUniqueTemplates;
+};
+
+export { getUniqueTemplatesViewedByUser };

--- a/backend/src/bundles/recently-viewed/types/recently-viewed-templates-query-result.type.ts
+++ b/backend/src/bundles/recently-viewed/types/recently-viewed-templates-query-result.type.ts
@@ -1,0 +1,12 @@
+import { type RecentlyViewedModel } from '../recently-viewed.model';
+import { type TemplateDto } from './types';
+
+interface RecentlyViewedTemplatesQueryResult extends RecentlyViewedModel {
+    templates: TemplateDto;
+    resumes: {
+        id: string;
+        resumeTitle: string;
+    };
+}
+
+export { type RecentlyViewedTemplatesQueryResult };

--- a/backend/src/bundles/recently-viewed/types/recently-viewed.repository.type.ts
+++ b/backend/src/bundles/recently-viewed/types/recently-viewed.repository.type.ts
@@ -1,6 +1,7 @@
 import {
     type RecentlyViewedRequestDto,
     type RecentlyViewedResponseDto,
+    type RecentlyViewedTemplatesResponseDto,
 } from './types';
 
 type IRecentlyViewedRepository = {
@@ -16,7 +17,7 @@ type IRecentlyViewedRepository = {
     findRecentlyViewedTemplatesByUser(data: {
         userId: string;
         limit: number;
-    }): Promise<RecentlyViewedResponseDto[]>;
+    }): Promise<RecentlyViewedTemplatesResponseDto[]>;
 
     create(
         userId: string,

--- a/backend/src/bundles/recently-viewed/types/recently-viewed.service.type.ts
+++ b/backend/src/bundles/recently-viewed/types/recently-viewed.service.type.ts
@@ -1,6 +1,7 @@
 import {
     type RecentlyViewedRequestDto,
     type RecentlyViewedResponseDto,
+    type RecentlyViewedTemplatesResponseDto,
 } from './types';
 
 type IRecentlyViewedService = {
@@ -9,12 +10,12 @@ type IRecentlyViewedService = {
     findRecentlyViewedTemplatesByUser(data: {
         userId: string;
         limit: number;
-    }): Promise<RecentlyViewedResponseDto[] | null>;
+    }): Promise<RecentlyViewedTemplatesResponseDto[]>;
 
     findRecentlyViewedResumesByUser(data: {
         userId: string;
         limit: number;
-    }): Promise<RecentlyViewedResponseDto[] | null>;
+    }): Promise<RecentlyViewedResponseDto[]>;
 
     create(
         userId: string,

--- a/backend/src/bundles/recently-viewed/types/types.ts
+++ b/backend/src/bundles/recently-viewed/types/types.ts
@@ -1,10 +1,12 @@
 export { type IRecentlyViewedController } from './recently-viewed.controller.type';
 export { type IRecentlyViewedRepository } from './recently-viewed.repository.type';
 export { type IRecentlyViewedService } from './recently-viewed.service.type';
+export { type RecentlyViewedTemplatesQueryResult } from './recently-viewed-templates-query-result.type';
 export {
     type RecentlyViewed,
     type RecentlyViewedRequestDto,
     type RecentlyViewedResponseDto,
     type RecentlyViewedResumesResponseDto,
     type RecentlyViewedTemplatesResponseDto,
+    type TemplateDto,
 } from 'shared/build/index.js';

--- a/frontend/src/bundles/home/components/components.tsx
+++ b/frontend/src/bundles/home/components/components.tsx
@@ -4,5 +4,6 @@ export { CreateResumeButton } from './home-top-section/components/create-resume-
 export { Greeting } from './home-top-section/components/greeting/greeting';
 export { HomeTopSection } from './home-top-section/home-top-section';
 export { PanelContainer } from './panel-container/panel-container';
+export { RecentlyViewedTemplates } from './recently-viewed-templates/recently-viewed-templates';
 export { ResumeSection } from './resume-section/resume-section';
 export { TemplateSection } from './template-section/template-section';

--- a/frontend/src/bundles/home/components/recently-viewed-templates/recently-viewed-templates.tsx
+++ b/frontend/src/bundles/home/components/recently-viewed-templates/recently-viewed-templates.tsx
@@ -1,0 +1,43 @@
+import {
+    useAppDispatch,
+    useAppSelector,
+    useCallback,
+    useEffect,
+} from '~/bundles/common/hooks/hooks';
+import { ResumeCard } from '~/bundles/home/components/components';
+import { actions as recentlyViewedActionCreator } from '~/bundles/recently-viewed/store/';
+
+const RecentlyViewedTemplates: React.FC = () => {
+    const dispatch = useAppDispatch();
+    const { recentlyViewedTemplates } = useAppSelector(
+        ({ recentlyViewed }) => ({
+            recentlyViewedTemplates: recentlyViewed.recentlyViewedTemplates,
+        }),
+    );
+
+    const loadRecentlyViewedTemplates = useCallback(() => {
+        void dispatch(recentlyViewedActionCreator.getRecentlyViewedTemplates());
+    }, [dispatch]);
+
+    useEffect(() => {
+        loadRecentlyViewedTemplates();
+    }, [loadRecentlyViewedTemplates]);
+
+    return (
+        <>
+            {recentlyViewedTemplates.length > 0 &&
+                recentlyViewedTemplates.map((recentlyViewed) => {
+                    return (
+                        <ResumeCard
+                            key={recentlyViewed.templateId}
+                            title={recentlyViewed.resumeTitle}
+                            image={recentlyViewed.template.image}
+                        />
+                    );
+                })
+            }
+        </>
+    );
+};
+
+export { RecentlyViewedTemplates };

--- a/frontend/src/bundles/home/pages/home.tsx
+++ b/frontend/src/bundles/home/pages/home.tsx
@@ -1,10 +1,10 @@
 import mockResume from '~/assets/img/mock-resume.png';
-import { useLoadTemplates } from '~/bundles/common/hooks/use-load-templates/use-load-templates.hook';
 import {
     CreateNewCard,
     CreateResumeButton,
     Greeting,
     HomeTopSection,
+    RecentlyViewedTemplates,
     ResumeCard,
     ResumeSection,
     TemplateSection,
@@ -13,8 +13,6 @@ import {
 import styles from './styles.module.scss';
 
 const Home: React.FC = () => {
-    const { templates } = useLoadTemplates();
-
     return (
         <div className={styles.layout}>
             <HomeTopSection>
@@ -37,16 +35,7 @@ const Home: React.FC = () => {
                 />
             </ResumeSection>
             <TemplateSection name="Templates">
-                {templates.length > 0 &&
-                    templates.map((template) => {
-                        return (
-                            <ResumeCard
-                                key={template.id}
-                                title="My Resume"
-                                image={template.image}
-                            />
-                        );
-                    })}
+                <RecentlyViewedTemplates />
             </TemplateSection>
         </div>
     );

--- a/frontend/src/bundles/recently-viewed/enums/enums.ts
+++ b/frontend/src/bundles/recently-viewed/enums/enums.ts
@@ -1,0 +1,1 @@
+export { RecentlyViewedApiPath } from 'shared/build/index.js';

--- a/frontend/src/bundles/recently-viewed/recently-viewed-api.ts
+++ b/frontend/src/bundles/recently-viewed/recently-viewed-api.ts
@@ -1,0 +1,40 @@
+import { ApiPath, ContentType } from '~/bundles/common/enums/enums.js';
+import { HttpApi } from '~/framework/api/api.js';
+import { type IHttp } from '~/framework/http/http.js';
+import { type IStorage } from '~/framework/storage/storage.js';
+
+import { RecentlyViewedApiPath } from './enums/enums.js';
+import { type RecentlyViewedTemplatesResponseDto } from './types/types.js';
+
+type Constructor = {
+    baseUrl: string;
+    http: IHttp;
+    storage: IStorage;
+};
+
+class RecentlyViewedApi extends HttpApi {
+    public constructor({ baseUrl, http, storage }: Constructor) {
+        super({ path: ApiPath.RECENTLY_VIEWED, baseUrl, http, storage });
+    }
+
+    public async getRecentlyViewedTemplates(
+        limit = '10',
+    ): Promise<RecentlyViewedTemplatesResponseDto[]> {
+        const query = `?limit=${limit}`;
+        const response = await this.load(
+            this.getFullEndpoint(
+                `${RecentlyViewedApiPath.RECENTLY_VIEWED_TEMPLATES}${query}`,
+                {},
+            ),
+            {
+                method: 'GET',
+                contentType: ContentType.JSON,
+                hasAuth: true,
+            },
+        );
+
+        return await response.json<RecentlyViewedTemplatesResponseDto[]>();
+    }
+}
+
+export { RecentlyViewedApi };

--- a/frontend/src/bundles/recently-viewed/recently-viewed.ts
+++ b/frontend/src/bundles/recently-viewed/recently-viewed.ts
@@ -1,0 +1,13 @@
+import { config } from '~/framework/config/config.js';
+import { http } from '~/framework/http/http.js';
+import { storage } from '~/framework/storage/storage.js';
+
+import { RecentlyViewedApi } from './recently-viewed-api.js';
+
+const recentlyViewedApi = new RecentlyViewedApi({
+    baseUrl: config.ENV.API.ORIGIN_URL,
+    storage,
+    http,
+});
+
+export { recentlyViewedApi };

--- a/frontend/src/bundles/recently-viewed/store/actions.ts
+++ b/frontend/src/bundles/recently-viewed/store/actions.ts
@@ -1,0 +1,18 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+import { type AsyncThunkConfig } from '~/bundles/common/types/types.js';
+
+import { type RecentlyViewedTemplatesResponseDto } from '../types/types';
+import { name as sliceName } from './slice.js';
+
+const getRecentlyViewedTemplates = createAsyncThunk<
+    RecentlyViewedTemplatesResponseDto[],
+    undefined,
+    AsyncThunkConfig
+>(`${sliceName}/templates`, async (_, { extra }) => {
+    const { recentlyViewedApi } = extra;
+
+    return await recentlyViewedApi.getRecentlyViewedTemplates();
+});
+
+export { getRecentlyViewedTemplates };

--- a/frontend/src/bundles/recently-viewed/store/index.ts
+++ b/frontend/src/bundles/recently-viewed/store/index.ts
@@ -1,0 +1,10 @@
+import { getRecentlyViewedTemplates } from './actions.js';
+import { actions } from './slice.js';
+
+const allActions = {
+    ...actions,
+    getRecentlyViewedTemplates,
+};
+
+export { allActions as actions };
+export { reducer } from './slice.js';

--- a/frontend/src/bundles/recently-viewed/store/slice.ts
+++ b/frontend/src/bundles/recently-viewed/store/slice.ts
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { DataStatus } from '~/bundles/common/enums/enums.js';
+import { type ValueOf } from '~/bundles/common/types/types.js';
+
+import { type RecentlyViewedTemplatesResponseDto } from '../types/types';
+import { getRecentlyViewedTemplates } from './actions.js';
+
+type State = {
+    recentlyViewedTemplates: RecentlyViewedTemplatesResponseDto[];
+    dataStatus: ValueOf<typeof DataStatus>;
+};
+
+const initialState: State = {
+    recentlyViewedTemplates: [],
+    dataStatus: DataStatus.IDLE,
+};
+
+const { reducer, actions, name } = createSlice({
+    initialState,
+    name: 'recently-viewed',
+    reducers: {},
+    extraReducers(builder) {
+        builder.addCase(getRecentlyViewedTemplates.pending, (state) => {
+            state.dataStatus = DataStatus.PENDING;
+        });
+        builder.addCase(
+            getRecentlyViewedTemplates.fulfilled,
+            (state, action) => {
+                state.recentlyViewedTemplates = action.payload;
+                state.dataStatus = DataStatus.FULFILLED;
+            },
+        );
+        builder.addCase(getRecentlyViewedTemplates.rejected, (state) => {
+            state.dataStatus = DataStatus.REJECTED;
+        });
+    },
+});
+
+export { actions, name, reducer };

--- a/frontend/src/bundles/recently-viewed/types/types.ts
+++ b/frontend/src/bundles/recently-viewed/types/types.ts
@@ -1,0 +1,4 @@
+export {
+    type RecentlyViewedResponseDto,
+    type RecentlyViewedTemplatesResponseDto,
+} from 'shared/build/index.js';

--- a/frontend/src/framework/store/store.package.ts
+++ b/frontend/src/framework/store/store.package.ts
@@ -14,6 +14,8 @@ import { paymentApi } from '~/bundles/payment/payment.js';
 import { reducer as paymentReducer } from '~/bundles/payment/store';
 import { profileApi } from '~/bundles/profile/profile';
 import { reducer as profileReducer } from '~/bundles/profile/store/';
+import { recentlyViewedApi } from '~/bundles/recently-viewed/recently-viewed';
+import { reducer as recentlyViewedReducer } from '~/bundles/recently-viewed/store/';
 import { reducer as usersReducer } from '~/bundles/users/store/';
 import { userApi } from '~/bundles/users/users.js';
 import { type IConfig } from '~/framework/config/config.js';
@@ -26,6 +28,7 @@ type RootReducer = {
     payment: ReturnType<typeof paymentReducer>;
     templates: ReturnType<typeof templatesReducer>;
     profile: ReturnType<typeof profileReducer>;
+    recentlyViewed: ReturnType<typeof recentlyViewedReducer>;
 };
 
 type ExtraArguments = {
@@ -35,6 +38,7 @@ type ExtraArguments = {
     storageApi: typeof storage;
     templateApi: typeof templateApi;
     profileApi: typeof profileApi;
+    recentlyViewedApi: typeof recentlyViewedApi;
 };
 
 class Store {
@@ -57,6 +61,7 @@ class Store {
                 payment: paymentReducer,
                 templates: templatesReducer,
                 profile: profileReducer,
+                recentlyViewed: recentlyViewedReducer,
             },
             middleware: (getDefaultMiddleware) => {
                 return getDefaultMiddleware({
@@ -76,6 +81,7 @@ class Store {
             storageApi: storage,
             templateApi,
             profileApi,
+            recentlyViewedApi,
         };
     }
 }

--- a/shared/src/bundles/recently-viewed/types/recently-viewed-templates-response-dto.type.ts
+++ b/shared/src/bundles/recently-viewed/types/recently-viewed-templates-response-dto.type.ts
@@ -1,10 +1,13 @@
+import { type TemplateDto } from '~/bundles/templates/templates';
+
 type RecentlyViewedTemplatesResponseDto = {
     id: string;
     userId: string;
     resumeId: string;
+    resumeTitle: string;
     templateId: string;
     viewedAt: string;
-    // add template: Template
+    template: TemplateDto;
 };
 
 export { type RecentlyViewedTemplatesResponseDto };

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -46,6 +46,7 @@ export {
 } from './bundles/resumes/resumes.js';
 export {
     type TemplateCreateItemRequestDto,
+    type TemplateDto,
     type TemplateGetAllItemResponseDto,
     type TemplateGetAllResponseDto,
     type TemplateUpdateItemRequestDto,


### PR DESCRIPTION
1. I've added recently viewed templates by user into home page.
2. + recently viewed action, slice, connect to store
3. change a bit method in recently viewed repository(to get resumeTitle).
4. + helper function to avoid duplicate tamplates