### PR TITLE
rg-188: The eye icon is covered by another icon when a user enters a password on the "Sign Up" page

### DIFF
--- a/frontend/src/assets/css/reset.scss
+++ b/frontend/src/assets/css/reset.scss
@@ -60,3 +60,8 @@ fieldset {
     padding: 0;
     border-width: 0;
 }
+
+input::-ms-reveal,
+input::-ms-clear {
+    display: none;
+}


### PR DESCRIPTION
![зображення](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/133093930/9e90aab1-44ba-4600-9407-67d98da96770)

Now ms edge eye icon is not shown