### PR TITLE
rg-199: Header navigation centering

### DIFF
--- a/frontend/src/bundles/common/components/tabs/style.module.scss
+++ b/frontend/src/bundles/common/components/tabs/style.module.scss
@@ -2,15 +2,19 @@
     display: flex;
     flex-direction: row;
     justify-content: center;
+    gap: 15px;
+    padding-right: 12.5vw;
 }
 
 a.tab__item {
-    padding: 5px 20px;
+    width: 140px;
+    padding: 5px 30px;
     color: var(--color-text-gray);
     font-weight: var(--font-weight-subtitle);
     font-size: var(--font-size-subtitle);
     font-family: var(--font-family-main);
     line-height: 24px;
+    text-align: center;
     border: none;
     border-radius: 34px;
     cursor: pointer;


### PR DESCRIPTION
Made navigation look more like the mockup design.

Before: 
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/70428008/61e01282-af7d-4628-a61c-ddcdc50e96e4)

After:
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/70428008/b4669032-3513-4e32-bbe5-3f71f3b274d4)
