### PR TITLE
rg-225: Invalid Password Message Fix BR-24

### DIFF
--- a/shared/src/bundles/users/enums/user-validation-message.enum.ts
+++ b/shared/src/bundles/users/enums/user-validation-message.enum.ts
@@ -9,7 +9,7 @@ enum UserValidationMessage {
     EMAIL_WRONG = 'Email is wrong',
     EMAIL_INVALID = 'Invalid email format. Please use a valid email address',
     PASSWORD_REQUIRED = 'Password is required',
-    PASSWORD_INVALID = 'Invalid password.Use 8-64 characters, mix uppercase, lowercase, numbers, and special characters. No spaces allowed',
+    PASSWORD_INVALID = 'Invalid password format',
     CONFIRM_PASSWORD_REQUIRED = 'Confirm password required',
     CONFIRM_PASSWORD_MATCH = 'Confirm password should match the password',
 }


### PR DESCRIPTION
Fill up sign up form with incorrect password like 123.
Expected result: Validation error message should be “Invalid password format”.

![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/60217935/b70ad53d-d96d-4a84-a46f-74bf9e008b3e)
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-resumegemm/assets/60217935/1b058f75-9f30-45bd-b84e-743549c023f8)
